### PR TITLE
Removes css import because lib author replaced css to css-in-jsx

### DIFF
--- a/src/components/RightSideBar/model/Spiner/Spiner.jsx
+++ b/src/components/RightSideBar/model/Spiner/Spiner.jsx
@@ -1,4 +1,3 @@
-import 'react-loader-spinner/dist/loader/css/react-spinner-loader.css';
 import { ThreeDots } from 'react-loader-spinner';
 
 export const Spiner = () => (


### PR DESCRIPTION
update to fix build.
as per https://github.com/mhnpd/react-loader-spinner/issues/124